### PR TITLE
Use importlib.metadata instead of depreciated pkg_resources

### DIFF
--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -204,7 +204,7 @@ def main():
     sys.argv = [args.process, *unknowns]
     # FIXME: this gets better in python 3.10
     # (process_entry_point,) = entry_points(group='console_scripts', name=args.process)
-    process_entry_point = [ep for ep in entry_points()['console_scripts'] if ep.name == 'gunw_burst'][0]
+    process_entry_point = [ep for ep in entry_points()['console_scripts'] if ep.name == args.process][0]
     sys.exit(
         process_entry_point.load()()
     )

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -3,10 +3,10 @@ import netrc
 import os
 import sys
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+from importlib.metadata import entry_points
 from pathlib import Path
 from typing import Optional
 
-from pkg_resources import load_entry_point
 
 from isce2_topsapp import (aws, burstio, download_aux_cal, download_dem_for_isce2,
                            download_orbits, download_slcs,
@@ -202,8 +202,11 @@ def main():
     args, unknowns = parser.parse_known_args()
 
     sys.argv = [args.process, *unknowns]
+    # FIXME: this gets better in python 3.10
+    # (process_entry_point,) = entry_points(group='console_scripts', name=args.process)
+    process_entry_point = [ep for ep in entry_points()['console_scripts'] if ep.name == 'gunw_burst'][0]
     sys.exit(
-        load_entry_point('isce2_topsapp', 'console_scripts', args.process)()
+        process_entry_point.load()()
     )
 
 


### PR DESCRIPTION
[pkg_resources](https://setuptools.pypa.io/en/latest/pkg_resources.html) provided by setuptools has a depreciation warning in their docs stating:
> :warning: Attention
> 
> Use of pkg_resources is discouraged in favor of [importlib.resources](https://docs.python.org/3/library/importlib.html#module-importlib.resources), [importlib.metadata](https://docs.python.org/3/library/importlib.metadata.html), and their backports ([importlib_resources](https://pypi.org/project/importlib_resources), [importlib_metadata](https://pypi.org/project/importlib_metadata)). Please consider using those libraries instead of pkg_resources.

This updates the entry_point loading method to use [`importlib.metadata`](https://docs.python.org/3.9/library/importlib.metadata.html#entry-points), which is part of the python standard library, for loading the `entry_point` functions. 

Note: we're [stuck at python 3.9 right now because ISCE2](https://github.com/ACCESS-Cloud-Based-InSAR/DockerizedTopsApp/blob/dev/environment.yml#L7) and this is a little clunkier than the [Python 3.10 version of `importlib.metadata`](https://docs.python.org/3.10/library/importlib.metadata.html#entry-points)